### PR TITLE
measure global CPU and ignore per core use

### DIFF
--- a/src/naemon/commands.cfg
+++ b/src/naemon/commands.cfg
@@ -288,7 +288,7 @@ define command{
 define command{
         command_name    ssh_cpu
         # https://raw.githubusercontent.com/georgehansper/check_cpu.py/master/check_cpu.py
-        command_line    $USER1$/check_by_ssh -H $HOSTADDRESS$ -o "ForwardX11=no" -o "UserKnownHostsFile=/home/naemon/.ssh/known_hosts_$ARG1$" -t 20 -p $ARG1$ -C '/usr/lib64/nagios/plugins/check_cpu.py -p 15 -w $_SERVICE_WARNING_THRESHOLD$ -c $_SERVICE_CRITICAL_THRESHOLD$'
+        command_line    $USER1$/check_by_ssh -H $HOSTADDRESS$ -o "ForwardX11=no" -o "UserKnownHostsFile=/home/naemon/.ssh/known_hosts_$ARG1$" -t 20 -p $ARG1$ -C '/usr/lib64/nagios/plugins/check_cpu.py -p 15 -w $_SERVICE_WARNING_THRESHOLD$ -c $_SERVICE_CRITICAL_THRESHOLD$ -W 100 -C 100'
         }
 
 define command{


### PR DESCRIPTION
I have been witnessing false-positive alerts when a single core is very high on CPU. I think in general we want to compare the overall CPU occupation with a known-to-be-OK baseline, rather than focusing on individual cores.

For instance, if a system launches a process with the `taskset` command it will be bound to a core and could take it to 100% whereas the rest of the system is idle. By default, I think we don't want to have this situation launch an alert.

The overall impact of a core at 100% depends on how many cores are available

@PrinceSalatyell are you using this on a scenario where you need to monitor per-core rather the average CPU use?